### PR TITLE
feat: implement client opt-out and opt-in

### DIFF
--- a/pkg/mycarehub/application/dto/input.go
+++ b/pkg/mycarehub/application/dto/input.go
@@ -431,3 +431,9 @@ type PinResetServiceRequestPayload struct {
 	CCCNumber   string `json:"cccNumber"`
 	PhoneNumber string `json:"phoneNumber"`
 }
+
+// OptInPayload models the details passed when opting a user in
+type OptInPayload struct {
+	PhoneNumber string          `json:"phoneNumber"`
+	Flavour     feedlib.Flavour `json:"flavour"`
+}

--- a/pkg/mycarehub/application/exceptions/error_codes.go
+++ b/pkg/mycarehub/application/exceptions/error_codes.go
@@ -372,4 +372,9 @@ const (
 	// GetAllRolesError implies that the system is unable to get all roles
 	// Its error code is 74
 	GetAllRolesError
+
+	// InactiveUser is returned when a user profile is not active. If they are inactive
+	// it mens they opted out and they should not be able to access the platform
+	// Its error code is 75
+	InactiveUser
 )

--- a/pkg/mycarehub/infrastructure/database/postgres/gorm/mock/gorm_mock.go
+++ b/pkg/mycarehub/infrastructure/database/postgres/gorm/mock/gorm_mock.go
@@ -109,6 +109,7 @@ type GormMock struct {
 	MockUpdateUserPinChangeRequiredStatusFn         func(ctx context.Context, userID string, flavour feedlib.Flavour, status bool) error
 	MockCheckIfClientHasUnresolvedServiceRequestsFn func(ctx context.Context, clientID string, serviceRequestType string) (bool, error)
 	MockGetAllRolesFn                               func(ctx context.Context) ([]*gorm.AuthorityRole, error)
+	MockUpdateUserActiveStatusFn                    func(ctx context.Context, userID string, flavour feedlib.Flavour, active bool) error
 }
 
 // NewGormMock initializes a new instance of `GormMock` then mocking the case of success.
@@ -782,6 +783,9 @@ func NewGormMock() *GormMock {
 				},
 			}, nil
 		},
+		MockUpdateUserActiveStatusFn: func(ctx context.Context, userID string, flavour feedlib.Flavour, active bool) error {
+			return nil
+		},
 	}
 }
 
@@ -1245,4 +1249,9 @@ func (gm *GormMock) SearchClientProfilesByCCCNumber(ctx context.Context, CCCNumb
 // SearchStaffProfileByStaffNumber mocks the implementation of getting staff profile using their staff number.
 func (gm *GormMock) SearchStaffProfileByStaffNumber(ctx context.Context, staffNumber string) ([]*gorm.StaffProfile, error) {
 	return gm.MockSearchStaffProfileByStaffNumberFn(ctx, staffNumber)
+}
+
+// UpdateUserActiveStatus mocks updating a user `active status`
+func (gm *GormMock) UpdateUserActiveStatus(ctx context.Context, userID string, flavour feedlib.Flavour, active bool) error {
+	return gm.MockUpdateUserActiveStatusFn(ctx, userID, flavour, active)
 }

--- a/pkg/mycarehub/infrastructure/database/postgres/gorm/update.go
+++ b/pkg/mycarehub/infrastructure/database/postgres/gorm/update.go
@@ -40,6 +40,7 @@ type Update interface {
 	InvalidateScreeningToolResponse(ctx context.Context, clientID string, questionID string) error
 	UpdateServiceRequests(ctx context.Context, payload []*ClientServiceRequest) (bool, error)
 	UpdateUserPinChangeRequiredStatus(ctx context.Context, userID string, flavour feedlib.Flavour, status bool) error
+	UpdateUserActiveStatus(ctx context.Context, userID string, flavour feedlib.Flavour, active bool) error
 }
 
 // LikeContent perfoms the actual database operation to update content like. The operation
@@ -896,6 +897,18 @@ func (db *PGInstance) UpdateServiceRequests(ctx context.Context, payload []*Clie
 func (db *PGInstance) UpdateUserPinChangeRequiredStatus(ctx context.Context, userID string, flavour feedlib.Flavour, status bool) error {
 	err := db.DB.Model(&User{}).Where(&User{UserID: &userID, Flavour: flavour}).Updates(map[string]interface{}{
 		"pin_change_required": status,
+	}).Error
+	if err != nil {
+		helpers.ReportErrorToSentry(err)
+		return err
+	}
+	return nil
+}
+
+// UpdateUserActiveStatus updates a user's active status
+func (db *PGInstance) UpdateUserActiveStatus(ctx context.Context, userID string, flavour feedlib.Flavour, active bool) error {
+	err := db.DB.Model(&User{}).Where(&User{UserID: &userID, Flavour: flavour}).Updates(map[string]interface{}{
+		"is_active": active,
 	}).Error
 	if err != nil {
 		helpers.ReportErrorToSentry(err)

--- a/pkg/mycarehub/infrastructure/database/postgres/mock/pg_mock.go
+++ b/pkg/mycarehub/infrastructure/database/postgres/mock/pg_mock.go
@@ -113,6 +113,7 @@ type PostgresMock struct {
 	MockSearchClientProfilesByCCCNumberFn           func(ctx context.Context, CCCNumber string) ([]*domain.ClientProfile, error)
 	MockCheckIfClientHasUnresolvedServiceRequestsFn func(ctx context.Context, clientID string, serviceRequestType string) (bool, error)
 	MockGetAllRolesFn                               func(ctx context.Context) ([]*domain.AuthorityRole, error)
+	MockUpdateUserActiveStatusFn                    func(ctx context.Context, userID string, flavour feedlib.Flavour, active bool) error
 }
 
 // NewPostgresMock initializes a new instance of `GormMock` then mocking the case of success.
@@ -717,6 +718,9 @@ func NewPostgresMock() *PostgresMock {
 				},
 			}, nil
 		},
+		MockUpdateUserActiveStatusFn: func(ctx context.Context, userID string, flavour feedlib.Flavour, active bool) error {
+			return nil
+		},
 	}
 }
 
@@ -1194,4 +1198,9 @@ func (gm *PostgresMock) GetAllRoles(ctx context.Context) ([]*domain.AuthorityRol
 // It returns clients profiles whose parts of the CCC number matches
 func (gm *PostgresMock) SearchClientProfilesByCCCNumber(ctx context.Context, CCCNumber string) ([]*domain.ClientProfile, error) {
 	return gm.MockSearchClientProfilesByCCCNumberFn(ctx, CCCNumber)
+}
+
+// UpdateUserActiveStatus mocks updating a user `active status`
+func (gm *PostgresMock) UpdateUserActiveStatus(ctx context.Context, userID string, flavour feedlib.Flavour, active bool) error {
+	return gm.MockUpdateUserActiveStatusFn(ctx, userID, flavour, active)
 }

--- a/pkg/mycarehub/infrastructure/database/postgres/pg_update.go
+++ b/pkg/mycarehub/infrastructure/database/postgres/pg_update.go
@@ -229,3 +229,8 @@ func (d *MyCareHubDb) UpdateServiceRequests(ctx context.Context, payload *domain
 func (d *MyCareHubDb) UpdateUserPinChangeRequiredStatus(ctx context.Context, userID string, flavour feedlib.Flavour, status bool) error {
 	return d.update.UpdateUserPinChangeRequiredStatus(ctx, userID, flavour, status)
 }
+
+// UpdateUserActiveStatus updates a user's `active` status. It will be used to opt out/in a user
+func (d *MyCareHubDb) UpdateUserActiveStatus(ctx context.Context, userID string, flavour feedlib.Flavour, active bool) error {
+	return d.update.UpdateUserActiveStatus(ctx, userID, flavour, active)
+}

--- a/pkg/mycarehub/infrastructure/database/postgres/pg_update_unit_test.go
+++ b/pkg/mycarehub/infrastructure/database/postgres/pg_update_unit_test.go
@@ -1807,3 +1807,52 @@ func TestMyCareHubDb_UpdateServiceRequests(t *testing.T) {
 		})
 	}
 }
+
+func TestMyCareHubDb_UpdateUserActiveStatus(t *testing.T) {
+	ctx := context.Background()
+	type args struct {
+		ctx     context.Context
+		userID  string
+		flavour feedlib.Flavour
+		active  bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Happy Case - Successfully update user active status",
+			args: args{
+				ctx:     ctx,
+				userID:  uuid.New().String(),
+				flavour: feedlib.FlavourConsumer,
+				active:  true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Sad Case - Fail to update user active status",
+			args: args{
+				ctx: ctx,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var fakeGorm = gormMock.NewGormMock()
+			d := NewMyCareHubDb(fakeGorm, fakeGorm, fakeGorm, fakeGorm)
+
+			if tt.name == "Sad Case - Fail to update user active status" {
+				fakeGorm.MockUpdateUserActiveStatusFn = func(ctx context.Context, userID string, flavour feedlib.Flavour, active bool) error {
+					return fmt.Errorf("failed to update user active status")
+				}
+			}
+
+			if err := d.UpdateUserActiveStatus(tt.args.ctx, tt.args.userID, tt.args.flavour, tt.args.active); (err != nil) != tt.wantErr {
+				t.Errorf("MyCareHubDb.UpdateUserActiveStatus() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/mycarehub/infrastructure/repository.go
+++ b/pkg/mycarehub/infrastructure/repository.go
@@ -119,4 +119,5 @@ type Update interface {
 	InvalidateScreeningToolResponse(ctx context.Context, clientID string, questionID string) error
 	UpdateServiceRequests(ctx context.Context, payload *domain.UpdateServiceRequestsPayload) (bool, error)
 	UpdateUserPinChangeRequiredStatus(ctx context.Context, userID string, flavour feedlib.Flavour, status bool) error
+	UpdateUserActiveStatus(ctx context.Context, userID string, flavour feedlib.Flavour, active bool) error
 }

--- a/pkg/mycarehub/presentation/config.go
+++ b/pkg/mycarehub/presentation/config.go
@@ -196,6 +196,11 @@ func Router(ctx context.Context) (*mux.Router, error) {
 		http.MethodPost,
 	).HandlerFunc(internalHandlers.CreatePinResetServiceRequest())
 
+	r.Path("/opt-in").Methods(
+		http.MethodOptions,
+		http.MethodPost,
+	).HandlerFunc(internalHandlers.OptIn())
+
 	// This endpoint will be used by external services to get a token that will be used to
 	// authenticate against our APIs
 	r.Path("/login").Methods(

--- a/pkg/mycarehub/presentation/graph/user.graphql
+++ b/pkg/mycarehub/presentation/graph/user.graphql
@@ -13,4 +13,5 @@ extend type Mutation {
   createOrUpdateClientCaregiver(caregiverInput: CaregiverInput): Boolean!
   registerClient(input: ClientRegistrationInput): ClientRegistrationOutput!
   registerStaff(input: StaffRegistrationInput!): StaffRegistrationOutput!
+  optOut(phoneNumber: String!, flavour: Flavour!): Boolean!
 }

--- a/pkg/mycarehub/presentation/graph/user.resolvers.go
+++ b/pkg/mycarehub/presentation/graph/user.resolvers.go
@@ -38,6 +38,10 @@ func (r *mutationResolver) RegisterStaff(ctx context.Context, input dto.StaffReg
 	return r.mycarehub.User.RegisterStaff(ctx, input)
 }
 
+func (r *mutationResolver) OptOut(ctx context.Context, phoneNumber string, flavour feedlib.Flavour) (bool, error) {
+	return r.mycarehub.User.Consent(ctx, phoneNumber, flavour, false)
+}
+
 func (r *queryResolver) GetCurrentTerms(ctx context.Context, flavour feedlib.Flavour) (*domain.TermsOfService, error) {
 	r.checkPreconditions()
 	return r.mycarehub.Terms.GetCurrentTerms(ctx, flavour)

--- a/pkg/mycarehub/presentation/rest/handlers_test.go
+++ b/pkg/mycarehub/presentation/rest/handlers_test.go
@@ -1810,3 +1810,129 @@ func TestMyCareHubHandlersInterfacesImpl_CreatePinResetServiceRequest(t *testing
 		})
 	}
 }
+
+func TestMyCareHubHandlersInterfacesImpl_OptIn(t *testing.T) {
+	ctx := context.Background()
+	headers, err := GetGraphQLHeaders(ctx)
+	if err != nil {
+		t.Errorf("failed to get GraphQL headers: %v", err)
+		return
+	}
+
+	missingPayload := &dto.OptInPayload{}
+	invalidPayload, err := json.Marshal(missingPayload)
+	if err != nil {
+		t.Errorf("failed to marshal payload")
+		return
+	}
+
+	invalidPayload1, err := json.Marshal(&dto.OptInPayload{Flavour: feedlib.Flavour("invalid"), PhoneNumber: "+254"})
+	if err != nil {
+		t.Errorf("failed to marshal payload")
+		return
+	}
+
+	type args struct {
+		url        string
+		httpMethod string
+		body       io.Reader
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantStatus int
+		wantErr    bool
+	}{
+		{
+			name: "Sad Case - Empty payload",
+			args: args{
+				url:        fmt.Sprintf("%s/opt-in", baseURL),
+				httpMethod: http.MethodPost,
+				body:       bytes.NewBuffer(invalidPayload),
+			},
+			wantStatus: http.StatusBadRequest,
+			wantErr:    true,
+		},
+		{
+			name: "Sad Case - Fail to opt back in",
+			args: args{
+				url:        fmt.Sprintf("%s/opt-in", baseURL),
+				httpMethod: http.MethodPost,
+				body:       bytes.NewBuffer(invalidPayload1),
+			},
+			wantStatus: http.StatusBadRequest,
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := http.NewRequest(
+				tt.args.httpMethod,
+				tt.args.url,
+				tt.args.body,
+			)
+			if err != nil {
+				t.Errorf("unable to compose request: %s", err)
+				return
+			}
+
+			if r == nil {
+				t.Errorf("nil request")
+				return
+			}
+
+			for k, v := range headers {
+				r.Header.Add(k, v)
+			}
+			client := http.DefaultClient
+			resp, err := client.Do(r)
+			if err != nil {
+				t.Errorf("request error: %s", err)
+				return
+			}
+
+			if resp == nil && !tt.wantErr {
+				t.Errorf("nil response")
+				return
+			}
+
+			dataResponse, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Errorf("can't read request body: %s", err)
+				return
+			}
+			if dataResponse == nil {
+				t.Errorf("nil response data")
+				return
+			}
+
+			data := map[string]interface{}{}
+			err = json.Unmarshal(dataResponse, &data)
+			if tt.wantErr && err != nil {
+				t.Errorf("bad data returned: %v", err)
+				return
+			}
+
+			if tt.wantErr {
+				errMsg, ok := data["error"]
+				if !ok {
+					t.Errorf("expected error: %s", errMsg)
+					return
+				}
+			}
+
+			if !tt.wantErr {
+				_, ok := data["error"]
+				if ok {
+					t.Errorf("error not expected")
+					return
+				}
+			}
+
+			if resp.StatusCode != tt.wantStatus {
+				t.Errorf("expected status %d, got %s", tt.wantStatus, resp.Status)
+				return
+			}
+		})
+	}
+}

--- a/pkg/mycarehub/usecases/user/mock/user_mock.go
+++ b/pkg/mycarehub/usecases/user/mock/user_mock.go
@@ -34,6 +34,7 @@ type UserUseCaseMock struct {
 	MockRegisteredFacilityPatientsFn    func(ctx context.Context, input dto.PatientSyncPayload) (*dto.PatientSyncResponse, error)
 	MockSetUserPINFn                    func(ctx context.Context, input dto.PINInput) (bool, error)
 	MockSearchStaffByStaffNumberFn      func(ctx context.Context, staffNumber string) ([]*domain.StaffProfile, error)
+	MockConsentFn                       func(ctx context.Context, phoneNumber string, flavour feedlib.Flavour, active bool) (bool, error)
 }
 
 // NewUserUseCaseMock creates in itializes create type mocks
@@ -161,6 +162,9 @@ func NewUserUseCaseMock() *UserUseCaseMock {
 		MockSetUserPINFn: func(ctx context.Context, input dto.PINInput) (bool, error) {
 			return true, nil
 		},
+		MockConsentFn: func(ctx context.Context, phoneNumber string, flavour feedlib.Flavour, active bool) (bool, error) {
+			return true, nil
+		},
 	}
 }
 
@@ -262,4 +266,9 @@ func (f *UserUseCaseMock) SetUserPIN(ctx context.Context, input dto.PINInput) (b
 // SearchStaffByStaffNumber mocks the implementation of getting staff profile using their staff number.
 func (f *UserUseCaseMock) SearchStaffByStaffNumber(ctx context.Context, staffNumber string) ([]*domain.StaffProfile, error) {
 	return f.MockSearchStaffByStaffNumberFn(ctx, staffNumber)
+}
+
+// Consent mocks the implementation of a user withdrawing or offering their consent to the app
+func (f *UserUseCaseMock) Consent(ctx context.Context, phoneNumber string, flavour feedlib.Flavour, active bool) (bool, error) {
+	return f.MockConsentFn(ctx, phoneNumber, flavour, active)
 }


### PR DESCRIPTION
This is a naive implementation of the opt-out and opt-in implementation
For now, it toggles the user's active field to true/false. When a user
is inactive, they'll be unable to access the platform.

# Review Checklist

[![Bugs](https://img.shields.io/badge/BugFixes-0-red.svg?style=for-the-badge)](https://shields.io/)
[![Features](https://img.shields.io/badge/Features-0-orange?style=for-the-badge)](https://shields.io/)
[![Tests](https://img.shields.io/badge/Tests-0-success.svg?style=for-the-badge)](https://shields.io/)

#### Summary*

- [ ] fix: Bug fix for `Add the items tackled here as checklists`
- [x] feat: Completed task
- [ ] chore: Incomplete task
  - [ ] test: Sub-task 1


#### Structure*

- [ ] The Pull Request has a `proper` title that conforms to our [MR title standards](https://gist.github.com/mikepea/863f63d6e37281e329f8)
- [ ] The Pull Request has one commit, and if there are more than one, they should be squashed
- [ ] The commit should have a proper title and a short description
- [ ] The commit must be signed off
- [ ] Unused imports are not present
- [ ] Dead code is not present
- [ ] Ensure dry running library to confirm changes

#### Tests

- [ ] Proper and high quality unit, integration and acceptance(if applicable) tests have been written
- [ ] The coverage threshold should not be lowered

### Sign off*

- [ ] All comments have been resolved by the reviewers
- [ ] Approved by Czar {replace_with_czar_name}
- [ ] Signed off by second reviewer {replace_with_name}
- [ ] Ensure all checks are done before merging :warning:
- [ ] All PRs needs to be signed before merging :warning:

#### N/B:

- Add a checklist if more than one item is done.
- Add screenshots and/or images where necessary
- Indicate any breakages caused in the UI :exclamation:
- Where necessary, indicate which issue the Pull Request solves (Closes #)
- Any new files are updated in the folder structure in the [README](../../README.md)